### PR TITLE
Renaming opa4j to jarl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,11 @@
 # Change Log
-All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
+All notable changes to this project will be documented in this file. 
+
+This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
-### Changed
-- Add a new arity to `make-widget-async` to provide a different widget shape.
-
-## [0.1.1] - 2022-01-29
-### Changed
-- Documentation on how to make the widgets.
-
-### Removed
-- `make-widget-sync` - we're all async, all the time.
-
-### Fixed
-- Fixed widget maker to keep working when daylight savings switches over.
-
-## 0.1.0 - 2022-01-29
 ### Added
-- Files from the new template.
-- Widget maker public API - `make-widget-sync`.
+- Everything
 
-[Unreleased]: https://github.com/your-name/opa4j/compare/0.1.1...HEAD
-[0.1.1]: https://github.com/your-name/opa4j/compare/0.1.0...0.1.1
+[Unreleased]: https://github.com/johanfylling/jarl/compare/0.1.0...HEAD
+[0.1.0]: https://github.com/johanfylling/jarl/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# JARL
+# Jarl
 
 The _JVM Alternative for the Rego Language_ (JARL) is an OPA evaluator for the JVM, written in Clojure.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-# opa4j
+# JARL
 
-An OPA evaluator for the JVM, written in Clojure.
-
-Project name is subject to change.
+The _JVM Alternative for the Rego Language_ (JARL) is an OPA evaluator for the JVM, written in Clojure.
 
 ## Usage
 

--- a/doc/intro.md
+++ b/doc/intro.md
@@ -1,3 +1,3 @@
-# Introduction to opa4j
+# Introduction to JARL
 
 TODO: write [great documentation](http://jacobian.org/writing/what-to-write/)

--- a/doc/intro.md
+++ b/doc/intro.md
@@ -1,3 +1,3 @@
-# Introduction to JARL
+# Introduction to Jarl
 
 TODO: write [great documentation](http://jacobian.org/writing/what-to-write/)

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (defproject jarl "0.1.0-SNAPSHOT"
-  :description "The JVM Alternative for the Rego Language (JARL)"
+  :description "Jarl, The JVM Alternative for the Rego Language"
   :url "https://github.com/johanfylling/jarl"
   :license {:name "Apache License Version 2.0"
             :url  "http://www.apache.org/licenses/LICENSE-2.0"}

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(defproject opa4j "0.1.0-SNAPSHOT"
-  :description "An OPA evaluator for the JVM"
-  :url "https://github.com/johanfylling/opa4j"
+(defproject jarl "0.1.0-SNAPSHOT"
+  :description "The JVM Alternative for the Rego Language (JARL)"
+  :url "https://github.com/johanfylling/jarl"
   :license {:name "Apache License Version 2.0"
             :url  "http://www.apache.org/licenses/LICENSE-2.0"}
   :dependencies [[org.clojure/clojure "1.11.1"]
@@ -9,9 +9,9 @@
             [lein-kibit "0.1.8"]
             [jonase/eastwood "1.2.3"]
             [com.github.clj-kondo/lein-clj-kondo "0.1.3"]]
-  :repl-options {:init-ns opa4j.core}
-  :main opa4j.core
-  :aot [opa4j.core opa4j.parser opa4j.api]
+  :repl-options {:init-ns jarl.core}
+  :main jarl.core
+  :aot [jarl.core jarl.parser jarl.api]
   :direct-linking true
   :aliases {"lint" ["do" ["eastwood"] ["kibit"] ["clj-kondo" "--lint" "src"]]}
   :source-paths ["src/main/clojure"]

--- a/src/main/clojure/jarl/api.clj
+++ b/src/main/clojure/jarl/api.clj
@@ -14,16 +14,16 @@
 ; limitations under the License.
 ;
 
-(ns opa4j.api
-  (:require [opa4j.parser :as parser]))
+(ns jarl.api
+  (:require [jarl.parser :as parser]))
 
 ;
 ; PLAN
 ;
 
 (gen-class
-  :name "se.fylling.opa4j.PlanImpl"
-  :implements [se.fylling.opa4j.Plan]
+  :name "se.fylling.jarl.PlanImpl"
+  :implements [se.fylling.jarl.Plan]
   :main false
   :prefix "-plan-"
   :constructors {[Object Object String] []}
@@ -34,31 +34,31 @@
 (defn -plan-init [info plan name]
   [[info] [info plan name]])
 
-(defn -plan-eval [^se.fylling.opa4j.PlanImpl this input]
+(defn -plan-eval [^se.fylling.jarl.PlanImpl this input]
   (let [[info plan name] (.state this)]
     (if (nil? plan)
       (throw (Exception. (format "plan '%s' doesn't exist" name)))
       (plan info input))))
 
-(defn -plans-toString [^se.fylling.opa4j.PlanImpl this]
+(defn -plans-toString [^se.fylling.jarl.PlanImpl this]
   (let [[_ _ name] (.state this)]
     name))
 
 ;
-; OPA4J
+; JARL
 ;
 
 (gen-class
-  :name "se.fylling.opa4j.Opa4jImpl"
-  :implements [se.fylling.opa4j.Opa4j]
-  :prefix "-opa4j-"
+  :name "se.fylling.jarl.JarlImpl"
+  :implements [se.fylling.jarl.Jarl]
+  :prefix "-jarl-"
   :main false
   :state "state"
   :init "init"
   :constructors {[Object] []}
   )
 
-(defn -opa4j-init [info]
+(defn -jarl-init [info]
   [[info] info])
 
 (defn plan-by-name [plans name]
@@ -69,24 +69,24 @@
           plan
           (recur (next plans)))))))
 
-(defn -opa4j-getPlan [^se.fylling.opa4j.Opa4jImpl this name]
+(defn -jarl-getPlan [^se.fylling.jarl.JarlImpl this name]
   (let [info (.state this)
         plans (get info :plans)
         plan (plan-by-name plans name)]
     (if (nil? plan)
       (throw (Exception. (format "plan '%s' doesn't exist" name)))
-      (new se.fylling.opa4j.PlanImpl info plan name))))
+      (new se.fylling.jarl.PlanImpl info plan name))))
 
 ;
-; OPA4J FACTORY
+; JARL FACTORY
 ;
 
 (gen-class
-  :name "se.fylling.opa4j.Opa4jFactory"
-  :prefix "-opa4j-factory-"
+  :name "se.fylling.jarl.JarlFactory"
+  :prefix "-jarl-factory-"
   :main false
-  :methods [^{:static true} [fromIr [String] se.fylling.opa4j.Opa4j]]
+  :methods [^{:static true} [fromIr [String] se.fylling.jarl.Jarl]]
   )
 
-(defn -opa4j-factory-fromIr [ir]
-  (new se.fylling.opa4j.Opa4jImpl (parser/parse ir)))
+(defn -jarl-factory-fromIr [ir]
+  (new se.fylling.jarl.JarlImpl (parser/parse ir)))

--- a/src/main/clojure/jarl/builtins/array.clj
+++ b/src/main/clojure/jarl/builtins/array.clj
@@ -14,14 +14,20 @@
 ; limitations under the License.
 ;
 
-(ns opa4j.builtins.registry
-  (:require [opa4j.builtins.array :as array]))
+(ns jarl.builtins.array
+  (:import (se.fylling.jarl BuiltinException)))
 
-(def builtins {
-               "array.concat" array/builtin-concat
-               "array.reverse" array/builtin-reverse
-               "array.slice" array/builtin-slice
-               })
+(defn builtin-concat [args]
+  (let [a (get args 0)
+        b (get args 1)]
+    (when-not (vector? a)
+      (throw (BuiltinException. (format "arg 0 is not an array"))))
+    (when-not (vector? b)
+      (throw (BuiltinException. (format "arg 1 is not an array"))))
+    (clojure.core/concat a b)))
 
-(defn get-builtin [name]
-  (get builtins name))
+(defn builtin-reverse [_]
+  (throw (BuiltinException. (format "not implemented"))))
+
+(defn builtin-slice [_]
+  (throw (BuiltinException. (format "not implemented"))))

--- a/src/main/clojure/jarl/builtins/registry.clj
+++ b/src/main/clojure/jarl/builtins/registry.clj
@@ -14,21 +14,14 @@
 ; limitations under the License.
 ;
 
-(ns opa4j.core
-  (:gen-class)
-  (:require [clojure.data.json :as json])
-  (:require [opa4j.parser :as parser]))
+(ns jarl.builtins.registry
+  (:require [jarl.builtins.array :as array]))
 
-(defn run-first-plan [data input]
-  (let [[name plan] (first (get data :plans))]
-    (println "running plan" name)
-    (let [result (plan data input)]
-      (println "Result-set:" result)
-      result)))
+(def builtins {
+               "array.concat" array/builtin-concat
+               "array.reverse" array/builtin-reverse
+               "array.slice" array/builtin-slice
+               })
 
-(defn -main
-  "Parses and the runs a plan"
-  ([] (run-first-plan (parser/parse-file "rego/simple/plan.json") {}))
-  ([ir-file input-json]
-   (let [input (json/read-str input-json)]
-     (run-first-plan (parser/parse-file ir-file) input))))
+(defn get-builtin [name]
+  (get builtins name))

--- a/src/main/clojure/jarl/core.clj
+++ b/src/main/clojure/jarl/core.clj
@@ -14,20 +14,21 @@
 ; limitations under the License.
 ;
 
-(ns opa4j.builtins.array
-  (:import (se.fylling.opa4j BuiltinException)))
+(ns jarl.core
+  (:gen-class)
+  (:require [clojure.data.json :as json])
+  (:require [jarl.parser :as parser]))
 
-(defn builtin-concat [args]
-  (let [a (get args 0)
-        b (get args 1)]
-    (when-not (vector? a)
-      (throw (BuiltinException. (format "arg 0 is not an array"))))
-    (when-not (vector? b)
-      (throw (BuiltinException. (format "arg 1 is not an array"))))
-    (clojure.core/concat a b)))
+(defn run-first-plan [data input]
+  (let [[name plan] (first (get data :plans))]
+    (println "running plan" name)
+    (let [result (plan data input)]
+      (println "Result-set:" result)
+      result)))
 
-(defn builtin-reverse [_]
-  (throw (BuiltinException. (format "not implemented"))))
-
-(defn builtin-slice [_]
-  (throw (BuiltinException. (format "not implemented"))))
+(defn -main
+  "Parses and the runs a plan"
+  ([] (run-first-plan (parser/parse-file "rego/simple/plan.json") {}))
+  ([ir-file input-json]
+   (let [input (json/read-str input-json)]
+     (run-first-plan (parser/parse-file ir-file) input))))

--- a/src/main/clojure/jarl/parser.clj
+++ b/src/main/clojure/jarl/parser.clj
@@ -14,13 +14,13 @@
 ; limitations under the License.
 ;
 
-(ns opa4j.parser
+(ns jarl.parser
   (:require [clojure.data.json :as json])
   (:require [clojure.edn :as edn])
   (:require [clojure.string :as str])
-  (:require [opa4j.builtins.registry :as builtins])
+  (:require [jarl.builtins.registry :as builtins])
   (:import (java.time Instant)
-           (se.fylling.opa4j BuiltinException)))
+           (se.fylling.jarl BuiltinException)))
 
 (declare make-block)
 (declare make-blocks)

--- a/src/main/java/se/fylling/jarl/BuiltinException.java
+++ b/src/main/java/se/fylling/jarl/BuiltinException.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package se.fylling.opa4j;
+package se.fylling.jarl;
 
 public class BuiltinException extends Exception {
     public BuiltinException(String message) {

--- a/src/main/java/se/fylling/jarl/Jarl.java
+++ b/src/main/java/se/fylling/jarl/Jarl.java
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-package se.fylling.opa4j;
+package se.fylling.jarl;
 
-public interface Opa4j {
+public interface Jarl {
     Plan getPlan(String name);
 }

--- a/src/main/java/se/fylling/jarl/Plan.java
+++ b/src/main/java/se/fylling/jarl/Plan.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package se.fylling.opa4j;
+package se.fylling.jarl;
 
 import java.util.List;
 import java.util.Map;

--- a/src/test/clojure/jarl/parser_test.clj
+++ b/src/test/clojure/jarl/parser_test.clj
@@ -12,9 +12,9 @@
 ;See the License for the specific language governing permissions and
 ;limitations under the License.
 
-(ns opa4j.parser-test
+(ns jarl.parser-test
   (:require [clojure.test :refer [deftest is testing]]
-            [opa4j.parser :refer [parse-file]]
+            [jarl.parser :refer [parse-file]]
             [clojure.java.io :as io]))
 
 (deftest simple-test


### PR DESCRIPTION
Will move the GH project to `johanfylling/jarl` once this is in.

Signed-off-by: Johan Fylling <johan.dev@fylling.se>